### PR TITLE
fix k6 permission in docker image

### DIFF
--- a/Dockerfile.tpl
+++ b/Dockerfile.tpl
@@ -3,7 +3,7 @@ FROM alpine:3.18 AS release
 
 RUN adduser -D -u 12345 -g 12345 k6
 
-COPY {{.Executable}} /usr/bin/k6
+COPY --chmod=755 {{.Executable}} /usr/bin/k6
 
 USER k6
 WORKDIR /home/k6
@@ -15,7 +15,7 @@ FROM release AS with-browser
 
 USER root
 
-COPY --from=release /usr/bin/k6 /usr/bin/k6
+COPY --chmod=755 --from=release /usr/bin/k6 /usr/bin/k6
 RUN apk --no-cache add chromium-swiftshader
 
 USER k6

--- a/NOTES.md.tpl
+++ b/NOTES.md.tpl
@@ -1,4 +1,4 @@
-🎉 **{{.Name}}** `{{.Version}}` is here!
+🎉 {{.Name}} `{{.Version}}` is here!
 
 ## Contents
 

--- a/action.yml
+++ b/action.yml
@@ -7,7 +7,7 @@ branding:
   color: orange
 
 inputs:
-  in:
+  args:
     description: input file name
     required: true
 

--- a/go.mod
+++ b/go.mod
@@ -4,18 +4,19 @@ go 1.22.4
 
 require (
 	github.com/go-task/slim-sprig/v3 v3.0.0
+	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/grafana/clireadme v0.1.0
 	github.com/grafana/k6foundry v0.2.0
 	github.com/samber/slog-logrus/v2 v2.5.0
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.8.1
+	github.com/spf13/pflag v1.0.5
 )
 
 require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/samber/lo v1.44.0 // indirect
 	github.com/samber/slog-common v0.17.0 // indirect
-	github.com/spf13/pflag v1.0.5 // indirect
 	golang.org/x/mod v0.17.0 // indirect
 	golang.org/x/sys v0.1.0 // indirect
 	golang.org/x/text v0.16.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-task/slim-sprig/v3 v3.0.0 h1:sUs3vkvUymDpBKi3qH1YSqBQk9+9D/8M2mN1vB6EwHI=
 github.com/go-task/slim-sprig/v3 v3.0.0/go.mod h1:W848ghGpv3Qj3dhTPRyJypKRiqCdHZiAzKg9hl15HA8=
+github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
+github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 github.com/grafana/clireadme v0.1.0 h1:KYEYSnYdSzmHf3bufaK6fQZ5j4dzvM/T+G6Ba+qNnAM=
 github.com/grafana/clireadme v0.1.0/go.mod h1:Wy4KIG2ZBGMYAYyF9l7qAy+yoJVasqk/txsRgoRI3gc=
 github.com/grafana/k6foundry v0.2.0 h1:+aE5wuCP0XNGNsxM7UiPj9hyw4RdWeW929PuGwLWIlg=

--- a/releases/v0.1.2.md
+++ b/releases/v0.1.2.md
@@ -1,0 +1,12 @@
+🎉 k6dist `v0.1.2` is here!
+
+## Fixes
+
+- The executable bit of the k6 binary was removed for some reason while copying to the Docker image. Now the executable bit is explicitly set during copying.
+
+## Refactors
+
+- GitHub Action input environment variables are now handled automatically based on the command flag. The name of the environment variable is generated from the name of the flag. In this way, all environment variables belonging to flags are processed.
+
+- The GitHub Action parameter corresponding to the positional argument is now `args`, i.e. the corresponding environment variable `INPUT_ARGS`. Its value is split using the shlex package.
+


### PR DESCRIPTION
## Fixes

- The executable bit of the k6 binary was removed for some reason while copying to the Docker image. Now the executable bit is explicitly set during copying.

## Refactors

- GitHub Action input environment variables are now handled automatically based on the command flag. The name of the environment variable is generated from the name of the flag. In this way, all environment variables belonging to flags are processed.

- The GitHub Action parameter corresponding to the positional argument is now `args`, i.e. the corresponding environment variable `INPUT_ARGS`. Its value is split using the shlex package.
