### PR TITLE
feat: use semantic versioning

### DIFF
--- a/.github/workflows/distro.yml
+++ b/.github/workflows/distro.yml
@@ -4,10 +4,6 @@
 # A new release is made if a new version of k6 or one or more of the extensions
 # has been released since the last distribution release.
 #
-# The distro release workflow should be scheduled once a day.
-# More than one distribution release cannot be made in one day,
-# because the release version is the date.
-#
 # Usage
 # -----
 #
@@ -21,7 +17,7 @@
 # ```
 # on:
 #  schedule:
-#    - cron: "0 0 * * *"
+#    - cron: "10 */2 * * *"
 #
 # jobs:
 #  distro:
@@ -134,17 +130,12 @@ jobs:
       - name: Latest Release Notes
         id: latest
         run: |
-          if gh api /repos/${{github.repository}}/releases/tag/$(date +%y.%m.%d) > /dev/null 2>/dev/null; then
-             echo "today=true" >> "$GITHUB_OUTPUT"
-          else
-            if gh api --jq .body /repos/${{github.repository}}/releases/latest  > ${{env.NOTES_LATEST}}  2>/dev/null; then
-             echo "notes=${{env.NOTES_LATEST}}" >> "$GITHUB_OUTPUT"
-            fi
+          if gh api --jq .body /repos/${{github.repository}}/releases/latest  > ${{env.NOTES_LATEST}}  2>/dev/null; then
+            echo "notes=${{env.NOTES_LATEST}}" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Build Distro
-        uses: grafana/k6dist@v0.1.7
-        if: ${{ steps.latest.outputs.today != 'true' }}
+        uses: grafana/k6dist@v0.1.8
         id: build
         with:
           args: "${{ inputs.args }}"

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ k6dist [flags] [registry-location]
 
 ```
       --distro-name string       distro name (default detect)
-      --distro-version string    distro version (default current date in YY.MM.DD format)
+      --distro-version string    distro version (default generated)
       --platform strings         target platforms (default [linux/amd64,darwin/amd64,windows/amd64])
       --executable string        executable file name (default "dist/{{.Name}}_{{.OS}}_{{.Arch}}/k6{{.ExeExt}}")
       --archive string           archive file name (default "dist/{{.Name}}_{{.Version}}_{{.OS}}_{{.Arch}}{{.ZipExt}}")

--- a/cmd/action.go
+++ b/cmd/action.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/google/shlex"
 	"github.com/spf13/pflag"
 )
@@ -57,7 +58,7 @@ func ghinput(args []string, flag *pflag.Flag) []string {
 }
 
 //nolint:forbidigo
-func emitOutput(changed bool, version string) error {
+func emitOutput(changed bool, version *semver.Version) error {
 	ghOutput := os.Getenv("GITHUB_OUTPUT")
 	if len(ghOutput) == 0 {
 		return nil
@@ -75,11 +76,13 @@ func emitOutput(changed bool, version string) error {
 		return err
 	}
 
-	slog.Debug("Emit version", "version", version)
+	if version != nil {
+		slog.Debug("Emit version", "version", version.Original())
 
-	_, err = fmt.Fprintf(file, "version=%s\n", version)
-	if err != nil {
-		return err
+		_, err = fmt.Fprintf(file, "version=%s\n", version.Original())
+		if err != nil {
+			return err
+		}
 	}
 
 	return file.Close()

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/grafana/k6dist
 go 1.22.4
 
 require (
+	github.com/Masterminds/semver/v3 v3.3.0
 	github.com/go-task/slim-sprig/v3 v3.0.0
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/grafana/clireadme v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/Masterminds/semver/v3 v3.3.0 h1:B8LGeaivUe71a5qox1ICM/JLl0NqZSW5CHyL+hmvYS0=
+github.com/Masterminds/semver/v3 v3.3.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/options.go
+++ b/options.go
@@ -3,6 +3,8 @@ package k6dist
 
 import (
 	"runtime"
+
+	"github.com/Masterminds/semver/v3"
 )
 
 // Options contains the optional parameters of the Build function.
@@ -11,8 +13,7 @@ type Options struct {
 	// Templating is not supported.
 	Name string
 	// Version contains distribution version.
-	// Templating is not supported.
-	Version string
+	Version *semver.Version
 	// Executable is the name of the k6 executable file to be built.
 	// Templating is supported.
 	// It defaults to DefaultExecutableTemplate.

--- a/releases/v0.1.8.md
+++ b/releases/v0.1.8.md
@@ -1,0 +1,11 @@
+🎉 k6dist `v0.1.8` is here!
+
+**Use semantic versioning**
+
+Semantic versioning is widespread and well-known and has many advantages. It is advisable to switch from the date-based version to the use of the semantic version.
+
+Assuming that k6 and its extensions use semantic versioning, the semantic version of the distribution will be generated as follows:
+
+- if a major version of a module (k6 or extension) is bumped, or a module is removed, the major version will be bumped (potential breaking change)
+- if the minor version of any module (k6 or extension) is bumped or a new module is added, the minor version will be bumped (backward compatible feature change)
+- otherwise, the patch version will be bumped

--- a/template.go
+++ b/template.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"text/template"
 
+	"github.com/Masterminds/semver/v3"
 	sprig "github.com/go-task/slim-sprig/v3"
 
 	"github.com/grafana/k6dist/internal/registry"
@@ -27,7 +28,7 @@ type releaseData struct {
 	Footer   string
 }
 
-func newInstsanceData(name, version string, platform *Platform) *instanceData {
+func newInstsanceData(name string, version *semver.Version, platform *Platform) *instanceData {
 	exe := ""
 	zip := ".tar.gz"
 
@@ -38,7 +39,7 @@ func newInstsanceData(name, version string, platform *Platform) *instanceData {
 
 	return &instanceData{
 		Name:    name,
-		Version: version,
+		Version: version.Original(),
 		OS:      platform.OS,
 		Arch:    platform.Arch,
 		ExeExt:  exe,
@@ -46,13 +47,13 @@ func newInstsanceData(name, version string, platform *Platform) *instanceData {
 	}
 }
 
-func newReleaseData(name, version string, reg registry.Registry) (*releaseData, error) {
-	footer, err := notesFooter(reg)
+func newReleaseData(name string, version *semver.Version, reg registry.Registry) (*releaseData, error) {
+	footer, err := notesFooter(version, reg)
 	if err != nil {
 		return nil, err
 	}
 
-	return &releaseData{Name: name, Version: version, Registry: reg, Footer: footer}, nil
+	return &releaseData{Name: name, Version: version.Original(), Registry: reg, Footer: footer}, nil
 }
 
 func expandTemplate(name string, tmplsrc string, data interface{}) (string, error) {


### PR DESCRIPTION
Semantic versioning is widespread and well-known and has many advantages. It is advisable to switch from the date-based version to the use of the semantic version.

Assuming that k6 and its extensions use semantic versioning, the semantic version of the distribution will be generated as follows:

- if a major version of a module (k6 or extension) is bumped, or a module is removed, the major version will be bumped (potential breaking change)
- if the minor version of any module (k6 or extension) is bumped or a new module is added, the minor version will be bumped (backward compatible feature change)
- otherwise, the patch version will be bumped